### PR TITLE
Add petri.com

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -216,3 +216,4 @@ instantmessaging-pa.googleapis.com
 feeds.feedburner.com
 res.cloudinary.com
 static.tp-link.com
+petri.com


### PR DESCRIPTION
Match found in https://v.firebog.net/hosts/Airelle-trc.txt:
   www.petri.com

Petri.com is a well known IT knowledgebase