### PR TITLE
Add sony.co.uk

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -217,3 +217,4 @@ feeds.feedburner.com
 res.cloudinary.com
 static.tp-link.com
 petri.com
+sony.co.uk


### PR DESCRIPTION
 Match found in https://adblock.mahakala.is:
   sony.co.uk
   www.sony.co.uk